### PR TITLE
Improve Yelp's workshop description and link working repo

### DIFF
--- a/cusec2019/src/app/components/workshops/workshops.component.html
+++ b/cusec2019/src/app/components/workshops/workshops.component.html
@@ -80,10 +80,9 @@
       <div class="col-md-4"></div>
       <div class="col-md-12">
         <p class="title"><strong>Hack your Python</strong></p>
-        <p>In this workshop, we're getting our hands dirty and using C to build an extension for the Python interpreter. Why would we do this? Writing critical parts of our software in a high-performance language has enabled us to supercharge our
-          backend and allowed us to access parts of the interpreter we wouldn't have been able to access in plain Python. We'll first build a small "classic" extension. Then we'll dive right in and tweak the behaviour of Python's garbage collector.
-          Knowledge of C/C++ is not required for the first part of the talk but is recommended for the second part. Requirements: A terminal with access to Python 3 and a C compiler (usually gcc), along with this skeleton repo provided here at a
-          later date from which we'll work.</p>
+        <p>In this workshop, we're getting our hands dirty and using C to build an extension for the Python interpreter. Why would we do this? Writing critical parts of our software in a high-performance language has enabled us to supercharge our backend and allowed us to access parts of the interpreter we wouldn't have been able to access in plain Python. This workshop runs in two parts: we'll first build a small "classic" extension; then we'll dive right in and tweak the behaviour of Python's garbage collector.</p>
+        <p><strong>Requirements:</strong> Python 3.x and a C compiler (usually gcc) available from the command line. Python 3.7 is required for the second part. Knowledge of C/C++ is not required for the first part of the talk but is recommended for the second part.</p>
+        <p>Please clone or download the <a href="https://github.com/yannlandry/cusec_workshop" style="font-weight:bolder">repository</a> we'll be using during the workshop!
       </div>
     </div>
     <hr>


### PR DESCRIPTION
I'm giving the Yelp workshop. I've slightly improved our description and added the link to the repo attendees will need to use.

Ran `ng serve` and everything looks good.